### PR TITLE
chore: license link changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ We welcome contributions! Here's how you can help:
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://opensource.org/license/mit) file for details.
 
 ## Acknowledgments
 


### PR DESCRIPTION
the old link was broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README license section with a direct link to the MIT License on the Open Source Initiative website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->